### PR TITLE
Some fixes for ruby 1.9

### DIFF
--- a/bin/craigwatch
+++ b/bin/craigwatch
@@ -290,12 +290,12 @@ class CraigReportDefinition #:nodoc:
     private
     
     def matches_all?(conditions, against)
-      against = against.to_a
+      against = against.lines.to_a unless against.nil?
       (conditions.nil? or conditions.all?{|c| against.any?{|a| match_against c, a } }) ? true : false
     end
     
     def doesnt_match_any?(conditions, against)
-      against = against.to_a
+      against = against.lines.to_a unless against.nil?
       (conditions.nil? or conditions.all?{|c| against.any?{|a| !match_against c, a } }) ? true : false
     end
     

--- a/lib/scraper.rb
+++ b/lib/scraper.rb
@@ -153,7 +153,7 @@ class CraigScrape::Scraper
       
     begin
       # This handles the redirects for us          
-      resp, data = Net::HTTP.new( uri.host, uri.port).get uri.request_uri, nil
+      resp, data = Net::HTTP.new( uri.host, uri.port).get uri.request_uri
   
       if resp.response.code == "200"
         # Check for gzip, and decode:


### PR DESCRIPTION
This got craigwatch to work with ruby 1.9 for me.

Use string.lines.to_a instead of string.to_a.

Don't pass nil to Net:Http#get.
