### PR TITLE
Fix price regex for real estate listings

### DIFF
--- a/lib/libcraigscrape.rb
+++ b/lib/libcraigscrape.rb
@@ -104,6 +104,7 @@ class CraigScrape
     ret = []
     fragments.each do |frag|
       each_post(frag) do |p|
+        next if p.post_time.nil?
         break if p.post_time <= newer_then
         ret << p
       end

--- a/lib/libcraigscrape.rb
+++ b/lib/libcraigscrape.rb
@@ -104,7 +104,7 @@ class CraigScrape
     ret = []
     fragments.each do |frag|
       each_post(frag) do |p|
-        break if p.post_date <= newer_then
+        break if p.post_time <= newer_then
         ret << p
       end
     end

--- a/lib/posting.rb
+++ b/lib/posting.rb
@@ -17,7 +17,7 @@ class CraigScrape::Posting < CraigScrape::Scraper
   HEADER_LOCATION = /^.+[ ]*\-[ ]*[\$]?[\d]+[ ]*\((.+)\)$/
   POSTING_ID      = /PostingID\:[ ]*([\d]+)/
   REPLY_TO        = /(.+)/
-  PRICE           = /((?:^\$[\d]+(?:\.[\d]{2})?)|(?:\$[\d]+(?:\.[\d]{2})?$))/
+  PRICE           = /((?:^\$[\d]+(?:\.[\d]{2})?)|(?:\$[\d]+(?:\.[\d]{2})?))/
   # NOTE: we implement the (?:) to first check the 'old' style format, and then the 'new style'
   # (As of 12/03's parse changes)
   USERBODY_PARTS  = /^(.+)\<div id\=\"userbody\">(.+)\<br[ ]*[\/]?\>\<br[ ]*[\/]?\>(.+)\<\/div\>(.+)$/m
@@ -297,7 +297,7 @@ class CraigScrape::Posting < CraigScrape::Scraper
   # Returns the best-guess of a price, judging by the label's contents. Price is available when pulled from the listing summary
   # and can be safely used if you wish conserve bandwidth by not pulling an entire post from a listing scrape.
   def price
-    $1.tr('$','').to_f if label and PRICE.match label
+    $1.tr('$','').to_f if header and PRICE.match header
   end
   
   # Returns the post contents with all html tags removed


### PR DESCRIPTION
In real estate listings, price is in the header and are like this: "$1600 / 1br - Quiet and Secluded Place in Kensington with Wood Floors (berkeley north / hills)"

because the regex has an end of line at the end, it won't catch any prices with text afterwards. I removed the end of line, and switched price to use header.

This still passes tests, but I haven't gotten around to writing a test case for a real estate listing. Will follow up.
